### PR TITLE
重新设计了泛型参数类型的处理

### DIFF
--- a/packages/minapp-generator/src/generator/struct/Func.ts
+++ b/packages/minapp-generator/src/generator/struct/Func.ts
@@ -17,10 +17,13 @@ export class Func extends Struct {
 
   toTSString(tabCount: number, promise: boolean = false) {
     if (promise && !this.promisable) promise = false
-    let {rows, args, rtns} = extractNSFuncToNamespace('', this.name, this.args, this.returns, tabCount, promise)
+    let {rows, args, rtns, generic} = extractNSFuncToNamespace('', this.name, this.args, this.returns, tabCount, promise)
 
     let prefix = TAB.repeat(tabCount)
     let fn = `${prefix}function ${this.name}(${args}): ${rtns}`
+    if(generic.length) {
+      fn = `${prefix}function ${this.name}<${generic.map(t => `${t}=any`).join(', ')}>(${args}): ${rtns}`
+    }
     return [...rows.map(r => prefix + r), joinDesc(this.desc, tabCount) + fn + EOL].join(EOL)
   }
 

--- a/packages/minapp-generator/src/generator/struct/Klass.ts
+++ b/packages/minapp-generator/src/generator/struct/Klass.ts
@@ -33,7 +33,7 @@ export class Klass extends Struct {
       } else if (canTypeExtract(d.type)) {
         let name = klassCase(d.name)
         let refName = this.name + '.' + name
-        rows.push(...extractNS(name, d.desc, d.type))
+        rows.push(...extractNS(name, d.desc, d.type).types)
         d = new Definition(d.name, new Type(refName), d)
       }
       return d.toTSString(tabCount + 1, true)

--- a/packages/minapp-generator/src/generator/struct/helper.ts
+++ b/packages/minapp-generator/src/generator/struct/helper.ts
@@ -3,43 +3,56 @@ MIT License http://www.opensource.org/licenses/mit-license.php
 Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 *******************************************************************/
 
-import {base} from './_'
-import {Type, ObjectType, ArrayObjectType, FunctionType} from './Type'
-import {Arg} from './Arg'
+import { base } from './_'
+import { Type, ObjectType, ArrayObjectType, FunctionType } from './Type'
+import { Arg } from './Arg'
 
-const {klassCase, TAB} = base
+const { klassCase, TAB } = base
 
 export function extractNS(name: string, desc: string[], type: ObjectType | FunctionType) {
   let types: string[] = []
-  let needExtracts: Array<{name: string, desc: string[], type: ObjectType | FunctionType}> = []
+  let needExtracts: Array<{ name: string, desc: string[], type: ObjectType | FunctionType }> = []
+  // 泛型参数
+  let generic: string[] = [];
+  let genericIdx = 0;
 
   pushDesc(types, desc)
   if (type instanceof ArrayObjectType) {
     types.push(`type ${name} = ${name}Item[]`)
-    types.push(...extractNS(name + 'Item', [], new ObjectType(type.definitions)))
+    types.push(...extractNS(name + 'Item', [], new ObjectType(type.definitions)).types)
   } else if (type instanceof ObjectType) {
     let ds = type.definitions
     if (!ds.length) {
       types.push(`type ${name} = {}`)
     } else {
       types.push(`type ${name} = {`)
+      // 记录type位置
+      let typesStart = types.length - 1;
       ds.forEach(d => {
         types.push(...d.doc.map(l => TAB + l))
         let newName: string
         if (canTypeExtract(d.type)) {
           newName = name + 'Prop' + klassCase(d.name)
-          needExtracts.push({name: newName, desc: d.desc, type: d.type})
+          needExtracts.push({ name: newName, desc: d.desc, type: d.type })
         } else {
           newName = d.type.toTSString(0)
+          // 只针对返回值带data或者值类型为any的均增加泛型
+          if ((d.name === 'data' || newName === 'any') && name === 'Promised') {
+            newName = 'T' + genericIdx++;
+            generic.push(newName);
+          }
         }
         types.push(`${TAB}${d.name}${d.required ? '' : '?'}: ${newName}`)
       })
+      if (generic.length) {
+        types[typesStart] = `type ${name}<${generic.map(t => `${t}=any`).join(', ')}> = {`
+      }
       types.push('}')
     }
   } else {
     let returns = name + 'Return'
     if (canTypeExtract(type.returns)) {
-      needExtracts.push({name: returns, desc: [], type: type.returns})
+      needExtracts.push({ name: returns, desc: [], type: type.returns })
     } else {
       returns = type.returns.toTSString(0)
     }
@@ -48,7 +61,7 @@ export function extractNS(name: string, desc: string[], type: ObjectType | Funct
     let args = type.args.map((a, i) => {
       let arg = name + 'Param' + (shouldAppendIndex ? i : '')
       if (canTypeExtract(a.type)) {
-        needExtracts.push({name: arg, desc: [], type: a.type})
+        needExtracts.push({ name: arg, desc: [], type: a.type })
       } else {
         arg = a.type.toTSString(0)
       }
@@ -58,9 +71,8 @@ export function extractNS(name: string, desc: string[], type: ObjectType | Funct
     types.push(`type ${name} = (${args}) => ${returns}`)
   }
 
-  needExtracts.forEach(ne => types.push(...extractNS(ne.name, ne.desc, ne.type)))
-
-  return types
+  needExtracts.forEach(ne => types.push(...extractNS(ne.name, ne.desc, ne.type).types))
+  return { types, generic }
 }
 
 export function extractNSFuncToNamespace(parentNamespace: string, namespace: string, args: Arg[], returns: Type, tabCount: number, promise: boolean) {
@@ -68,6 +80,7 @@ export function extractNSFuncToNamespace(parentNamespace: string, namespace: str
   let rows: string[] = []
   let rtns: string | undefined
   let prefix = (parentNamespace ? parentNamespace + '.' : '') + namespace
+  let genericNS: string[] = []
 
   makeFunctionObjectFunctionParamToRequired(args)
 
@@ -79,13 +92,19 @@ export function extractNSFuncToNamespace(parentNamespace: string, namespace: str
         let successArgType = a.type.getSuccessFirstArgType()
         a.type.removePromisableKey()
         if (canTypeExtract(successArgType)) {
-          rows.push(...extractNS('Promised', [], successArgType))
-          rtns = `Promise<${prefix}.Promised>`
+          let { types, generic } = extractNS('Promised', [], successArgType);
+          rows.push(...types)
+          if (generic.length) {
+            genericNS = generic
+            rtns = `Promise<${prefix}.Promised<${generic.join(', ')}>>`
+          } else {
+            rtns = `Promise<${prefix}.Promised>`
+          }
         } else {
           rtns = `Promise<${successArgType.toTSString(0)}>`
         }
       }
-      rows.push(...extractNS(name, [], a.type))
+      rows.push(...extractNS(name, [], a.type).types)
       let optional = a.optional
       if (promise && !optional && a.type instanceof ObjectType) {
         // type 可能变成一个空对象，promise 条件下空对象后就变成 optional（promise 会自动注入一个对象）
@@ -99,7 +118,7 @@ export function extractNSFuncToNamespace(parentNamespace: string, namespace: str
 
   if (!rtns) { // rtns 可能是从 args[0] 中抽取出来，转化成 Promise 的接口
     if (canTypeExtract(returns)) {
-      rows.push(...extractNS('Return', [], returns))
+      rows.push(...extractNS('Return', [], returns).types)
       rtns = `${prefix}.Return`
     } else {
       rtns = returns.toTSString(0)
@@ -115,7 +134,8 @@ export function extractNSFuncToNamespace(parentNamespace: string, namespace: str
   return {
     rows,
     args: argstr,
-    rtns
+    rtns,
+    generic: genericNS
   }
 }
 

--- a/packages/minapp-generator/src/generator/struct/helper.ts
+++ b/packages/minapp-generator/src/generator/struct/helper.ts
@@ -37,7 +37,7 @@ export function extractNS(name: string, desc: string[], type: ObjectType | Funct
         } else {
           newName = d.type.toTSString(0)
           // 只针对返回值带data或者值类型为any的均增加泛型
-          if ((d.name === 'data' || newName === 'any') && name === 'Promised') {
+          if (name === 'Promised' && (d.name === 'data' || newName === 'any')) {
             newName = 'T' + genericIdx++;
             generic.push(newName);
           }

--- a/packages/minapp-generator/src/modify/api/location/location.ts
+++ b/packages/minapp-generator/src/modify/api/location/location.ts
@@ -1,17 +1,15 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
-      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
+      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['Number', 'Number', 'Number', 'Number', 'Number', 'Number', 'Number']}},
+      {type: 'update', index: 3, col: {splice: [1, 0], head: '类型', rows: ['String', 'String', 'Number', 'Number']}},
     ]
   }
 }

--- a/packages/minapp-generator/src/modify/api/media-picture/media-background-audio.ts
+++ b/packages/minapp-generator/src/modify/api/media-picture/media-background-audio.ts
@@ -1,0 +1,16 @@
+/******************************************************************
+MIT License http://www.opensource.org/licenses/mit-license.php
+Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
+*******************************************************************/
+
+import {ApiModifier, TemplateMeta} from '../..'
+
+export default class extends ApiModifier {
+  modify(): TemplateMeta[] {
+    return [
+    //   {type: 'update', index: 1, head: { col:0, from: '参数', to: '属性'}},
+      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['Number', 'Number', 'Number', 'Number', 'String']}},
+      {type: 'update', index: 1, col: {splice: [2, 0], head: '必填', rows: ['是', '是', '是', '是', '是']}}
+    ]
+  }
+}

--- a/packages/minapp-generator/src/modify/api/media-picture/media-record.ts
+++ b/packages/minapp-generator/src/modify/api/media-picture/media-record.ts
@@ -1,16 +1,13 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
       {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
     ]
   }

--- a/packages/minapp-generator/src/modify/api/media-picture/media-video.ts
+++ b/packages/minapp-generator/src/modify/api/media-picture/media-video.ts
@@ -1,17 +1,14 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
-      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
+      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String', 'number', 'number', 'number', 'number']}},
     ]
   }
 }

--- a/packages/minapp-generator/src/modify/api/systeminfo/device.ts
+++ b/packages/minapp-generator/src/modify/api/systeminfo/device.ts
@@ -1,16 +1,13 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
       {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
     ]
   }

--- a/packages/minapp-generator/src/modify/api/systeminfo/scancode.ts
+++ b/packages/minapp-generator/src/modify/api/systeminfo/scancode.ts
@@ -1,17 +1,14 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
-      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
+      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['Object', 'String', 'String', 'String']}},
     ]
   }
 }

--- a/packages/minapp-generator/src/modify/api/systeminfo/systemInfo.ts
+++ b/packages/minapp-generator/src/modify/api/systeminfo/systemInfo.ts
@@ -1,17 +1,14 @@
 /******************************************************************
 MIT License http://www.opensource.org/licenses/mit-license.php
-Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 Author AlexStacker <lexusunx@gmail.com> (https://github.com/AlexStacker)
 *******************************************************************/
 
-import {TemplateMeta, ApiModifier} from '../..'
+import {ApiModifier, TemplateMeta} from '../..'
 
 export default class extends ApiModifier {
   modify(): TemplateMeta[] {
     return [
-      {type: 'merge', toIndex: 3, fromIndex: 4, prefixes: ['fileList[].']},
-      {type: 'update', index: 8, head: {col: 1, from: '说明', to: '类型'}},
-      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String']}},
+      {type: 'update', index: 1, col: {splice: [1, 0], head: '类型', rows: ['String', 'String', 'Number', 'Number', 'Number', 'Number', 'Number', 'Number', 'String', 'String', 'String', 'String', 'Number', 'String']}},
     ]
   }
 }

--- a/packages/minapp-generator/src/modify/inc/ModifierApi.ts
+++ b/packages/minapp-generator/src/modify/inc/ModifierApi.ts
@@ -3,9 +3,9 @@ MIT License http://www.opensource.org/licenses/mit-license.php
 Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 *******************************************************************/
 
-import {Modifier} from './Modifier'
-import {isSectionHead} from '../../generator/base/'
-import {TemplateMeta} from './interface'
+import { Modifier } from './Modifier'
+import { isSectionHead } from '../../generator/base/'
+import { TemplateMeta } from './interface'
 
 export class ApiModifier extends Modifier {
   modify($root: Cheerio): TemplateMeta[] | void {
@@ -26,8 +26,8 @@ export class ApiModifier extends Modifier {
         let $fromTable = $(tables[m.fromIndex])
         let $target = $(tables[m.toIndex]).find('tbody')
 
-        let {body} = this.g.getTableData($fromTable)
-        let {prefixes, suffixes, splice} = m
+        let { body } = this.g.getTableData($fromTable)
+        let { prefixes, suffixes, splice } = m
         body.forEach(row => {
           if (prefixes) prefixes.forEach((prefix, i) => row[i] = prefix + row[i])
           if (suffixes) suffixes.forEach((suffix, i) => row[i] = row[i] + suffix)
@@ -54,7 +54,7 @@ export class ApiModifier extends Modifier {
         }
       } else if (m.type === 'update') {
         let $table = $(tables[m.index])
-        let {head, body} = this.g.getTableData($table)
+        let { head, body } = this.g.getTableData($table)
         if (m.head) {
           this.assert(head[m.head.col] === m.head.from)
           $table.find('thead th').eq(m.head.col).text(m.head.to)
@@ -64,17 +64,19 @@ export class ApiModifier extends Modifier {
           $table.find('tbody tr').eq(m.body.row).find('td').eq(m.body.col).text(m.body.to)
         }
         // 增加、删除或者修改列
-        if(m.col) {
-          let {splice, rows} = m.col;
-          head.splice.apply(head, splice.concat(m.col.head))
-          let $ths = head.map(r => `<th>${r}</th>`);
-          $table.find('thead').html(`<tr>${$ths.join('')}</tr>`);
+        if (m.col) {
+          let { splice, rows, head: title } = m.col
+          // 判断微信文档是否增加了参数或者已经增加了当前字段
+          this.assert(body.length === rows.length || head.indexOf(title) === -1)
+          head.splice.apply(head, splice.concat(title))
+          let $ths = head.map(r => `<th>${r}</th>`)
+          $table.find('thead').html(`<tr>${$ths.join('')}</tr>`)
 
           let $body = body.map((row, idx) => {
-              row.splice.apply(row, splice.concat(rows[idx] || ''));
-              return `<tr>${row.map(r => `<td>${r}</td>`).join('')}</tr>`;
-          });
-          $table.find('tbody').html($body.join(''));
+            row.splice.apply(row, splice.concat(rows[idx] || ''))
+            return `<tr>${row.map(r => `<td>${r}</td>`).join('')}</tr>`
+          })
+          $table.find('tbody').html($body.join(''))
         }
       } else if (m.type === 'ignoreHeadWarn') {
         let $table = $(tables[m.index])

--- a/packages/minapp-generator/src/modify/inc/ModifierApi.ts
+++ b/packages/minapp-generator/src/modify/inc/ModifierApi.ts
@@ -63,6 +63,19 @@ export class ApiModifier extends Modifier {
           this.assert(body[m.body.row][m.body.col] === m.body.from)
           $table.find('tbody tr').eq(m.body.row).find('td').eq(m.body.col).text(m.body.to)
         }
+        // 增加、删除或者修改列
+        if(m.col) {
+          let {splice, rows} = m.col;
+          head.splice.apply(head, splice.concat(m.col.head))
+          let $ths = head.map(r => `<th>${r}</th>`);
+          $table.find('thead').html(`<tr>${$ths.join('')}</tr>`);
+
+          let $body = body.map((row, idx) => {
+              row.splice.apply(row, splice.concat(rows[idx] || ''));
+              return `<tr>${row.map(r => `<td>${r}</td>`).join('')}</tr>`;
+          });
+          $table.find('tbody').html($body.join(''));
+        }
       } else if (m.type === 'ignoreHeadWarn') {
         let $table = $(tables[m.index])
         this.assert($table.find('thead th').eq(m.col).text() === m.from)

--- a/packages/minapp-generator/src/modify/inc/interface.ts
+++ b/packages/minapp-generator/src/modify/inc/interface.ts
@@ -34,6 +34,11 @@ export interface TableUpdateTemplateMeta {
     col: number
     from: string
     to: string
+  },
+  col?: {
+    splice: any[]
+    head: string
+    rows: any[]
   }
 }
 


### PR DESCRIPTION
1、深入了解了一下各个函数的关系、重新实现了泛型参数的处理方式
2、增加了一个 增加参数表格列的功能， 对参数类型没有的情况下手动增加一个参数类型列，补全部分微信API文档缺失的参数类型