### PR TITLE
Fix: use types instead of typings in package.json

### DIFF
--- a/packages/minapp-core/package.json
+++ b/packages/minapp-core/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.12",
   "description": "微信小程序 api 的 typings，同时提供 promise 版",
   "main": "system.js",
-  "typings": "system.d.ts",
+  "types": "system.d.ts",
   "scripts": {
     "test": "echo 0",
     "lint": "tslint src/**/*.ts",


### PR DESCRIPTION
根据 typescript 文档，这里应该是 types 字段 https://www.typescriptlang.org/docs/handbook/module-resolution.html
设定为 types，我这里不需要在 jsconfig.json/tsconfig.json 中配置就可以找到了所有的定义文件了。