### PR TITLE
修复组件的 dataset 类型定义

### DIFF
--- a/packages/minapp-wx/typing/component.d.ts
+++ b/packages/minapp-wx/typing/component.d.ts
@@ -114,7 +114,7 @@ declare interface Component {
   /** 节点id */
   id: string
   /** 节点dataset */
-  dataset: string
+  dataset: { [key:string]: any }
 
   /** 设置data并执行视图层渲染 */
   setData(newData: any, callback?: any): void


### PR DESCRIPTION
经测试，dataset 是一个对象类型，其属性名只能为字符串，其属性值可以为任意类型。