### PR TITLE
add localAssetsFileDir to cli build option

### DIFF
--- a/packages/minapp-cli/package.json
+++ b/packages/minapp-cli/package.json
@@ -61,6 +61,7 @@
 	},
 	"devDependencies": {
 		"@types/autoprefixer": "^6.7.3",
+		"@types/copy-webpack-plugin": "^4.4.2",
 		"@types/fs-extra": "^5.0.2",
 		"@types/inquirer": "0.0.41",
 		"@types/json5": "^0.0.29",
@@ -69,6 +70,7 @@
 		"@types/webpack": "^4.1.4",
 		"@types/webpack-dev-server": "^2.9.4",
 		"@types/webpack-sources": "^0.1.4",
+		"copy-webpack-plugin": "^4.6.0",
 		"ts-lint": "^4.5.1",
 		"typescript": "^2.8.0"
 	}

--- a/packages/minapp-cli/src/bin/minapp-build.ts
+++ b/packages/minapp-cli/src/bin/minapp-build.ts
@@ -12,6 +12,7 @@ export const buildOptions: cli.Options = {
   'p | publicPath': '<string> static file\'s publicPath, just like `output.publicPath` in webpack',
   'w | watch':      '<boolean> watch mode, without webpack-dev-server',
   'e | empty':      '<boolean> empty distDir before compile',
+  'l | useLocalAssetsFile': '<boolean> use Local assets path instead of publicPath'
 }
 
 /**
@@ -24,6 +25,7 @@ export function buildCommand(res: cli.Response) {
   if (res.distDir) process.env.MINAPP_DIST_DIR = res.distDir
   if (res.pretty)  process.env.MINAPP_PRETTY = 'true'
   if (res.publicPath)  process.env.MINAPP_PUBLIC_PATH = res.publicPath
+  if (res.useLocalAssetsFile) process.env.MINAPP_USE_LOCAL_ASSETS_FILE = 'true'
 
   compiler(res.watch, null, {empty: res.empty})
 }

--- a/packages/minapp-cli/src/config/env.ts
+++ b/packages/minapp-cli/src/config/env.ts
@@ -68,7 +68,7 @@ export function getEnv() {
 
   // 是否美化代码（即，不使用代码压缩工具）
   const pretty = !!MINAPP.PRETTY
-
+  const useLocalAssetsFile = !!MINAPP.USE_LOCAL_ASSETS_FILE
 
   // 入口文件
   const entry = (minapp.component
@@ -93,6 +93,7 @@ export function getEnv() {
     modulesDir,
     // sourceMap,
     pretty,
+    useLocalAssetsFile
   }
   debug(r)
   return r

--- a/packages/minapp-cli/src/config/minapp.ts
+++ b/packages/minapp-cli/src/config/minapp.ts
@@ -13,6 +13,8 @@ export namespace minapp {
     srcDir: string
     distDir: string
 
+    localAssetsFileDir: string
+
     /** url-loader limit, 单位：B */
     urlLoaderLimit: number
 
@@ -92,6 +94,7 @@ export function getMinappConfig(rootDir: string) {
     browsers: ['last 7 android version', 'last 5 chrome version', 'last 5 safari version'],
     unitTransformer: {},
     devServer: {},
+    localAssetsFileDir: ''
   }, minapp.compiler || {})
 
   if (minapp.component) minapp.component = path.resolve(rootDir, minapp.component)

--- a/packages/minapp-cli/src/config/webpack.config.ts
+++ b/packages/minapp-cli/src/config/webpack.config.ts
@@ -10,6 +10,7 @@ import {localConfig} from './local'
 import {env} from './env'
 import {JSON_REGEXP} from '../base/helper'
 import {getLoader, ExtractMinappCode, WriteFile, RemoveLessCache} from '../webpack/'
+import copyWebpackPlugin = require('copy-webpack-plugin')
 
 const {mode, entry, rootDir, srcDir, distDir, modulesDir} = env
 
@@ -63,8 +64,13 @@ const plugins: any[] = [
   }),
   new webpack.EnvironmentPlugin(['NODE_ENV']),
   new ExtractMinappCode(env),
-  new RemoveLessCache(env),
+  new RemoveLessCache(env)
 ]
+if (env.useLocalAssetsFile) {
+  plugins.push(new copyWebpackPlugin([
+    { from: path.resolve(srcDir, env.minapp.compiler.localAssetsFileDir), to: env.minapp.compiler.localAssetsFileDir }
+  ]))
+}
 if (env.hasServer) {
   plugins.push(new WriteFile(env))
 }

--- a/packages/minapp-cli/src/webpack/loader/wxml-loader.ts
+++ b/packages/minapp-cli/src/webpack/loader/wxml-loader.ts
@@ -6,7 +6,7 @@ Author Mora <qiuzhongleiabc@126.com> (https://github.com/qiu8310)
 import * as parser from '@minapp/wxml-parser'
 import {EOL} from 'os'
 const debug = require('debug')('minapp:cli:wxml-loader')
-
+import {env} from '../../config/env'
 import {Loader} from './Loader'
 import {map, STYLE_RESOURCE_REGEXP} from '../util'
 
@@ -127,7 +127,8 @@ export default class WxmlLoader extends Loader {
       } else {
         if (this.shouleMakeRequireFile(absFile)) {
           if (this.isStaticFile(absFile) && typeof attr.value === 'string') {
-            attr.value = attr.value.replace(src, await this.loadStaticFile(absFile, src, false))
+            const file = await this.loadStaticFile(absFile, src, false, env.useLocalAssetsFile)
+            attr.value = attr.value.replace(src, file)
           } else if (node.name === 'import' || node.name === 'include') {
             attr.value = this.getExtractRequirePath(absFile, '.wxml')
             requires.push(absFile)


### PR DESCRIPTION
用于解决[这个问题](https://github.com/qiu8310/minapp/issues/99) ，不知道这个方法是否可行？

Usage:
再 minapp.json 里添加 `localAssetsFileDir` 配置
```
{
  ...
  "compiler": {
    ...
    "localAssetsFileDir": "images"
  }
}
```

然后 `minapp build --useLocalAssetsFile --pretty`
就会把 src/images 目录直接拷贝到 dist/images