### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -56,6 +56,10 @@ const siteConfig = {
   scripts: ['https://buttons.github.io/buttons.js'],
   // You may provide arbitrary config keys to be used as needed by your template.
   repoUrl: 'https://github.com/qiu8310/minapp',
+  algolia: {
+    apiKey: 'ad598e670d42575d2c914e7cdc1e6711',
+    indexName: 'minapp',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.